### PR TITLE
Add error handler for year header not being provided

### DIFF
--- a/webviewer/views.py
+++ b/webviewer/views.py
@@ -29,7 +29,9 @@ class Events(viewsets.ViewSet):
         except ValueError:
             res = {'errorMessage': "Please send a valid integer for the year you want."}
             return Response(res, status.HTTP_400_BAD_REQUEST)
-            
+        except KeyError:
+            res = {'errorMessage': "Please provide the desired year as a header with key 'year'."}
+            return Response(res, status.HTTP_400_BAD_REQUEST)
 
         if year < 2018:
             res = {'errorMessage': "Telemetry is only available from 2018 onwards."}


### PR DESCRIPTION
Returns HTTP 400 if client sends a request to /api/events without a "year" header

Linked to #2 